### PR TITLE
Add retry backoff for 503 responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "head-monitor",
-  "version": "0.0.2",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "head-monitor",
-      "version": "0.0.2",
+      "version": "0.2.1",
       "license": "ISC",
       "dependencies": {
         "commander": "^14.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "head-monitor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsc && node dist/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npx tsx --test src/**/*.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/measurement.test.ts
+++ b/src/measurement.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { getRetryAfterMs } from './utils';
+
+// Test the retry logic extracted into getRetryAfterMs.
+// HeadMonitor itself starts an infinite loop in its constructor,
+// making it impractical to unit test directly without refactoring.
+// These tests verify the retry delay calculation that drives the backoff behavior.
+
+function mockResponse(status: number, headers?: Record<string, string>): Response {
+  return new Response(null, { status, headers });
+}
+
+describe('503 retry delay calculation', () => {
+  it('uses 1s default when portal returns 503 without Retry-After', () => {
+    const resp = mockResponse(503);
+    const delay = getRetryAfterMs(resp, 1000);
+    assert.strictEqual(delay, 1000);
+  });
+
+  it('respects Retry-After seconds header on 503', () => {
+    const resp = mockResponse(503, { 'Retry-After': '5' });
+    const delay = getRetryAfterMs(resp, 1000);
+    assert.strictEqual(delay, 5000);
+  });
+
+  it('respects Retry-After: 0', () => {
+    const resp = mockResponse(503, { 'Retry-After': '0' });
+    const delay = getRetryAfterMs(resp, 1000);
+    assert.strictEqual(delay, 0);
+  });
+
+  it('respects Retry-After with HTTP-date in the future', () => {
+    const futureDate = new Date(Date.now() + 10000).toUTCString();
+    const resp = mockResponse(503, { 'Retry-After': futureDate });
+    const delay = getRetryAfterMs(resp, 1000);
+    assert.ok(delay >= 9000 && delay <= 11000, `expected ~10000, got ${delay}`);
+  });
+
+  it('clamps to default when Retry-After date is in the past', () => {
+    const pastDate = new Date(Date.now() - 5000).toUTCString();
+    const resp = mockResponse(503, { 'Retry-After': pastDate });
+    const delay = getRetryAfterMs(resp, 1000);
+    assert.strictEqual(delay, 1000);
+  });
+
+  it('falls back to default for invalid Retry-After', () => {
+    const resp = mockResponse(503, { 'Retry-After': 'not-a-number' });
+    const delay = getRetryAfterMs(resp, 1000);
+    assert.strictEqual(delay, 1000);
+  });
+});

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -1,5 +1,5 @@
 import { Measurement, PortalApi } from './config';
-import { sleep } from './utils';
+import { sleep, getRetryAfterMs } from './utils';
 import { recordDelay } from './metrics';
 
 export class HeadMonitor {
@@ -53,6 +53,13 @@ export class HeadMonitor {
           continue;
         }
 
+        if (response.status === 503) {
+          const delayMs = getRetryAfterMs(response, 1000);
+          this.log(`got 503, retrying in ${delayMs}ms`);
+          await sleep(delayMs);
+          continue;
+        }
+
         if (!response.ok) {
           const body = await response.text();
           throw new Error(`HTTP ${response.status} ${body}`);
@@ -75,7 +82,8 @@ export class HeadMonitor {
         }
         lastBlock = newBlock;
       } catch (error) {
-        this.log(`error during stream request to ${this.measurement.target.url}, retrying:`, error);
+        this.log(`error during stream request to ${this.measurement.target.url}, retrying in 1000ms:`, error);
+        await sleep(1000);
       }
     }
   }
@@ -91,13 +99,17 @@ export class HeadMonitor {
         if (response.ok) {
           const head = await response.json();
           return head["number"];
+        } else if (response.status === 503) {
+          const delayMs = getRetryAfterMs(response, 1000);
+          console.log(`Couldn't fetch head from ${head_url}, got 503, retrying in ${delayMs}ms`);
+          await sleep(delayMs);
         } else {
-          const body = response.text();
+          const body = await response.text();
           throw new Error(`HTTP ${response.status} ${body}`);
         }
       } catch (error) {
-        console.log(`Couldn't fetch head from ${head_url}, retrying in 500ms:`, error);
-        await sleep(500);
+        console.log(`Couldn't fetch head from ${head_url}, retrying in 1000ms:`, error);
+        await sleep(1000);
       }
     }
   }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { getRetryAfterMs } from './utils';
+
+function mockResponse(retryAfter?: string): Response {
+  const headers = new Headers();
+  if (retryAfter !== undefined) {
+    headers.set('Retry-After', retryAfter);
+  }
+  return { headers } as Response;
+}
+
+describe('getRetryAfterMs', () => {
+  it('returns default when no Retry-After header', () => {
+    assert.strictEqual(getRetryAfterMs(mockResponse(), 1000), 1000);
+  });
+
+  it('parses Retry-After as seconds', () => {
+    assert.strictEqual(getRetryAfterMs(mockResponse('5'), 1000), 5000);
+  });
+
+  it('parses Retry-After as zero seconds', () => {
+    assert.strictEqual(getRetryAfterMs(mockResponse('0'), 1000), 0);
+  });
+
+  it('parses Retry-After as fractional seconds', () => {
+    assert.strictEqual(getRetryAfterMs(mockResponse('1.5'), 1000), 1500);
+  });
+
+  it('parses Retry-After as HTTP-date in the future', () => {
+    const futureDate = new Date(Date.now() + 3000).toUTCString();
+    const result = getRetryAfterMs(mockResponse(futureDate), 1000);
+    // Should be roughly 3000ms, allow tolerance for date rounding
+    assert.ok(result >= 2000 && result <= 4000, `expected ~3000, got ${result}`);
+  });
+
+  it('returns default for HTTP-date in the past', () => {
+    const pastDate = new Date(Date.now() - 5000).toUTCString();
+    const result = getRetryAfterMs(mockResponse(pastDate), 1000);
+    assert.strictEqual(result, 1000);
+  });
+
+  it('returns default for unparseable value', () => {
+    assert.strictEqual(getRetryAfterMs(mockResponse('garbage'), 1000), 1000);
+  });
+
+  it('uses provided default value', () => {
+    assert.strictEqual(getRetryAfterMs(mockResponse(), 2500), 2500);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,16 @@
 export function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+export function getRetryAfterMs(response: Response, defaultMs: number): number {
+  const header = response.headers.get('Retry-After');
+  if (header == null) return defaultMs;
+
+  const seconds = Number(header);
+  if (!Number.isNaN(seconds)) return seconds * 1000;
+
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) return Math.max(date - Date.now(), defaultMs);
+
+  return defaultMs;
+}


### PR DESCRIPTION
## Summary

Previously, when the portal responded with 503, requests were retried immediately with no delay. This could cause excessive load during outages. This PR adds proper retry backoff:

- **`src/utils.ts`** — Added `getRetryAfterMs()` helper that parses the `Retry-After` header (supports both seconds and HTTP-date formats), falling back to a provided default.

- **`src/measurement.ts`** — Three changes:
  1. **`streamBlocks()`**: 503 responses are now caught explicitly before the generic error check, sleeping for the `Retry-After` duration (default 1s) before retrying.
  2. **`streamBlocks()` catch block**: Added a 1s backoff on any error (previously retried immediately).
  3. **`getLastBlock()`**: 503 responses are handled separately with `Retry-After` support (default 1s). Also bumped the general error retry from 500ms to 1000ms.

## Test plan

- [ ] Deploy to staging and verify 503 responses are retried with backoff
- [ ] Verify `Retry-After` header is respected when present
- [ ] Confirm normal (non-503) errors still retry with 1s delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)