### PR TITLE
allow to configure readiness check per dataset

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,8 @@ datasets:
           dataset_kind: evm
           url: https://portal.sqd.dev/datasets/base-mainnet
   solana-mainnet:
+    readiness:
+      max_lag_seconds: 30
     measurements:
       processing_time:
         reference:

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,8 +18,13 @@ export interface Measurement {
   target: PortalApi;
 }
 
+export interface Readiness {
+  max_lag_seconds: number;
+}
+
 export interface Dataset {
   measurements: Record<string, Measurement>;
+  readiness?: Readiness;
 }
 
 export interface Config {
@@ -59,6 +64,10 @@ function validateDataset(dataset: any, datasetName: string): asserts dataset is 
     throw new Error(`Invalid dataset ${datasetName}: must be an object`);
   }
 
+  if (dataset.readiness) {
+    validateReadiness(dataset.readiness, datasetName)
+  }
+
   if (!dataset.measurements || typeof dataset.measurements !== 'object') {
     throw new Error(`Invalid dataset ${datasetName}: measurements must be an object`);
   }
@@ -96,5 +105,19 @@ function validateMeasurement(measurement: any, datasetName: string, measurementN
 
   if (!measurement.target.dataset_kind || !['evm', 'solana', 'bitcoin', 'hyperliquid-fills', 'hyperliquid-replica-cmds'].includes(measurement.target.dataset_kind)) {
     throw new Error(`Invalid measurement ${measurementName} in dataset ${datasetName}: target dataset_kind must be 'evm' or 'solana' or 'bitcoin' or 'hyperliquid-fills' or 'hyperliquid-replica-cmds'`);
+  }
+}
+
+function validateReadiness(readiness: any, datasetName: string): asserts readiness is Readiness {
+  if (typeof readiness !== 'object') {
+    throw new Error(`Invalid dataset ${datasetName}: readiness must be an object`);
+  }
+
+  if (readiness.max_lag_seconds == null) {
+    throw new Error(`Invalid dataset ${datasetName}: readiness max lag seconds is required`);
+  }
+
+  if (typeof readiness.max_lag_seconds !== 'number' || readiness.max_lag_seconds <= 0) {
+    throw new Error(`Invalid dataset ${datasetName}: readiness max lag seconds must be a positive number`)
   }
 }

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -1,11 +1,12 @@
 import { Measurement, PortalApi } from './config';
-import { sleep, getRetryAfterMs } from './utils';
+import { sleep, getRetryAfterMs, toMilliseconds } from './utils';
 import { recordDelay } from './metrics';
 
 export class HeadMonitor {
   public readonly datasetName: string;
   public readonly measurementName: string;
   public readonly measurement: Measurement;
+  public lastBlockTimestamp?: number;
 
   constructor(
     datasetName: string,
@@ -81,6 +82,7 @@ export class HeadMonitor {
           yield { blockNumber: i, timestamp };
         }
         lastBlock = newBlock;
+        this.lastBlockTimestamp = toMilliseconds(blockData.header.timestamp);
       } catch (error) {
         this.log(`error during stream request to ${this.measurement.target.url}, retrying in 1000ms:`, error);
         await sleep(1000);
@@ -145,7 +147,7 @@ export class HeadMonitor {
 
   private genQuery(fromBlock: number, kind: PortalApi['dataset_kind']): string {
     let type = this.getQueryType(kind)
-    return JSON.stringify({ fromBlock, type, fields: { block: { number: true } } });
+    return JSON.stringify({ fromBlock, type, fields: { block: { number: true, timestamp: true } } });
   }
 
   private getQueryType(kind: PortalApi['dataset_kind']): string {

--- a/src/metrics_server.ts
+++ b/src/metrics_server.ts
@@ -25,7 +25,7 @@ export class MetricsServer {
             res.writeHead(500, { 'Content-Type': 'text/plain' });
             res.end(`Error generating metrics: ${error}`);
           }
-        } else if (req.url === '/ready' && req.method === 'GET') {
+        } else if (req.url === '/upstream-ready' && req.method === 'GET') {
           const ready = this.isReady();
           const status = ready ? 200 : 503;
           res.writeHead(status, { 'Content-Type': 'text/plain' });

--- a/src/metrics_server.ts
+++ b/src/metrics_server.ts
@@ -4,9 +4,11 @@ import { getMetricsRegistry } from './metrics';
 export class MetricsServer {
   private server?: http.Server;
   private readonly port: number;
+  private readonly isReady: () => boolean;
 
-  constructor(port: number = 3000) {
+  constructor(port: number = 3000, isReady: () => boolean) {
     this.port = port;
+    this.isReady = isReady;
   }
 
   start(): Promise<void> {
@@ -23,6 +25,11 @@ export class MetricsServer {
             res.writeHead(500, { 'Content-Type': 'text/plain' });
             res.end(`Error generating metrics: ${error}`);
           }
+        } else if (req.url === '/ready' && req.method === 'GET') {
+          const ready = this.isReady();
+          const status = ready ? 200 : 503;
+          res.writeHead(status, { 'Content-Type': 'text/plain' });
+          res.end(ready ? 'OK' : 'Not Ready');
         } else {
           res.writeHead(404, { 'Content-Type': 'text/plain' });
           res.end('Not Found');

--- a/src/service.ts
+++ b/src/service.ts
@@ -6,11 +6,13 @@ export class Service {
   private config: Config;
   private metricsServer: MetricsServer;
   private port: number;
+  private monitors: Record<string, HeadMonitor[]>;
 
   constructor(configPath?: string, port: number = 3000) {
     this.config = loadConfig(configPath);
-    this.metricsServer = new MetricsServer(port);
+    this.metricsServer = new MetricsServer(port, () => this.isReady());
     this.port = port;
+    this.monitors = {};
   }
 
   async start(): Promise<void> {
@@ -18,19 +20,37 @@ export class Service {
     console.log(`Metrics server listening on port ${this.port}`);
 
     for (const [datasetName, dataset] of Object.entries(this.config.datasets ?? {})) {
+      let monitors = [];
       for (const [measurementName, measurement] of Object.entries(dataset.measurements)) {
         console.log(`Monitoring ${datasetName}.${measurementName}`);
 
-        new HeadMonitor(
+        monitors.push(new HeadMonitor(
           datasetName,
           measurementName,
           measurement,
-        );
+        ));
       }
+      this.monitors[datasetName] = monitors;
     }
   }
 
   async stop(): Promise<void> {
     await this.metricsServer.stop();
+  }
+
+  isReady(): boolean {
+    let now = Date.now();
+
+    for (const [datasetName, dataset] of Object.entries(this.config.datasets ?? {})) {
+      if (dataset.readiness == null) continue;
+
+      for (const monitor of this.monitors[datasetName]) {
+        if (monitor.lastBlockTimestamp == null) return false;
+        let lag = Math.floor((now - monitor.lastBlockTimestamp) / 1000);
+        if (lag > dataset.readiness.max_lag_seconds) return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,13 @@ export function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+export function toMilliseconds(timestamp: number): number {
+  if (timestamp < 1e12) {
+    return timestamp * 1000;
+  }
+  return timestamp;
+}
+
 export function getRetryAfterMs(response: Response, defaultMs: number): number {
   const header = response.headers.get('Retry-After');
   if (header == null) return defaultMs;


### PR DESCRIPTION
readiness per dataset will allow us to prevent hotblocks from serving data in case it's not syncronized yet