### PR TITLE
Decouple readiness from reference data services

### DIFF
--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -7,6 +7,7 @@ export class HeadMonitor {
   public readonly measurementName: string;
   public readonly measurement: Measurement;
   public lastBlockTimestamp?: number;
+  private measuring = false;
 
   constructor(
     datasetName: string,
@@ -23,18 +24,37 @@ export class HeadMonitor {
   private async run(): Promise<void> {
     const blockStream = this.streamBlocks();
 
+    // Consume the target stream at its own pace so `lastBlockTimestamp`
+    // (which drives readiness) tracks the head regardless of how healthy the
+    // reference data services are. The delay measurement queries those
+    // reference services, so it must NOT backpressure the stream: run it
+    // single-flight (skip overlapping blocks) instead of awaiting per block.
     for await (const { blockNumber, timestamp } of blockStream) {
-      const reference = await this.fetchReferenceTimestamp(blockNumber);
-
-      if (reference === undefined) {
-        continue;
-      }
-
-      const delay = timestamp - reference;
-
-      recordDelay(this.datasetName, this.measurementName, delay);
-      this.log(`block ${blockNumber} delay: ${delay}ms`);
+      this.measureDelay(blockNumber, timestamp);
     }
+  }
+
+  private measureDelay(blockNumber: number, timestamp: number): void {
+    if (this.measuring) {
+      return;
+    }
+    this.measuring = true;
+    this.doMeasureDelay(blockNumber, timestamp)
+      .catch((error) => this.log(`delay measurement failed:`, error))
+      .finally(() => { this.measuring = false; });
+  }
+
+  private async doMeasureDelay(blockNumber: number, timestamp: number): Promise<void> {
+    const reference = await this.fetchReferenceTimestamp(blockNumber);
+
+    if (reference === undefined) {
+      return;
+    }
+
+    const delay = timestamp - reference;
+
+    recordDelay(this.datasetName, this.measurementName, delay);
+    this.log(`block ${blockNumber} delay: ${delay}ms`);
   }
 
   private async* streamBlocks(): AsyncGenerator<{ blockNumber: number; timestamp: number }> {


### PR DESCRIPTION
## Problem

Pod readiness (`/upstream-ready`) is computed from each block timestamp vs `max_lag_seconds`. The intent is for readiness to reflect how fresh the **target** head is.

However, the implementation `await`s `fetchReferenceTimestamp()`. When a data service is unreachable, the `/upstream-ready` often returns 503.

This surfaced in production: a `head-monitor` sidecar was stuck not-ready because its config referenced `evm-drpc-binance-mainnet-hotblocks-service` that was not deployed.

## Fix

Move the reference-delay measurement into a single-flight `measureDelay()` that runs **without backpressuring** the stream — overlapping blocks are skipped rather than queued. `lastBlockTimestamp` now tracks the target head at the target's own pace, fully independent of reference-service health.

## Tradeoff

Under sustained reference slowness, the delay histogram becomes best-effort sampled rather than strictly per-block. This is intended: dropping samples when the reference is overloaded is preferable to backpressuring readiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)