### PR TITLE
Add structured log levels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "head-monitor",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "head-monitor",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "ISC",
       "dependencies": {
         "commander": "^14.0.1",
+        "pino": "^10.3.1",
+        "pino-pretty": "^13.1.3",
         "prom-client": "^15.1.3",
-        "yaml": "^2.8.1"
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -27,6 +29,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
@@ -45,10 +53,25 @@
         "undici-types": "~7.12.0"
       }
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/bintrees": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -59,6 +82,155 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/fast-copy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.4.tgz",
+      "integrity": "sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "license": "MIT"
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/prom-client": {
       "version": "15.1.3",
@@ -73,6 +245,86 @@
         "node": "^16 || ^18 || >=20"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tdigest": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
@@ -81,6 +333,24 @@
       "dependencies": {
         "bintrees": "1.0.2"
       }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.2",
@@ -103,16 +373,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "head-monitor",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,9 @@
   },
   "dependencies": {
     "commander": "^14.0.1",
+    "pino": "^10.3.1",
+    "pino-pretty": "^13.1.3",
     "prom-client": "^15.1.3",
-    "yaml": "^2.8.1"
+    "yaml": "^2.9.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Service } from './service';
 import { Command } from 'commander';
+import { ensureError, logger } from './logger';
 
 function parseArgs(): { port: number; config?: string } {
   const program = new Command();
@@ -16,7 +17,7 @@ function parseArgs(): { port: number; config?: string } {
   const port = parseInt(options.port, 10);
 
   if (isNaN(port) || port < 1 || port > 65535) {
-    console.error('Error: Port must be a number between 1 and 65535');
+    logger.error({ message: 'Port must be a number between 1 and 65535' });
     process.exit(1);
   }
 
@@ -36,9 +37,18 @@ async function main() {
     // Keep the process alive
     await new Promise(() => { });
   } catch (error) {
-    console.error('Failed to start:', error);
+    logger.error({
+      message: 'Failed to start head monitor',
+      error: ensureError(error),
+    });
     process.exit(1);
   }
 }
 
-main().catch(console.error);
+main().catch((error) => {
+  logger.fatal({
+    message: 'Unexpected head monitor failure',
+    error: ensureError(error),
+  });
+  process.exit(1);
+});

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,26 @@
+import pino from 'pino';
+
+const pretty = Boolean(process.stdout.isTTY) && process.env.LOG_PRETTY !== 'false';
+
+export const logger = pino({
+  base: undefined,
+  level: process.env.LOG_LEVEL ?? 'info',
+  messageKey: 'message',
+  timestamp: pino.stdTimeFunctions.isoTime,
+  serializers: {
+    error: pino.stdSerializers.errWithCause,
+  },
+  transport: pretty
+    ? {
+        target: 'pino-pretty',
+        options: {
+          messageKey: 'message',
+          singleLine: true,
+        },
+      }
+    : undefined,
+});
+
+export function ensureError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -1,6 +1,8 @@
 import { Measurement, PortalApi } from './config';
+import { ensureError, logger } from './logger';
 import { sleep, getRetryAfterMs, toMilliseconds } from './utils';
 import { recordDelay } from './metrics';
+import type { Logger } from 'pino';
 
 export class HeadMonitor {
   public readonly datasetName: string;
@@ -8,6 +10,7 @@ export class HeadMonitor {
   public readonly measurement: Measurement;
   public lastBlockTimestamp?: number;
   private measuring = false;
+  private readonly logger: Logger;
 
   constructor(
     datasetName: string,
@@ -17,6 +20,7 @@ export class HeadMonitor {
     this.datasetName = datasetName;
     this.measurementName = measurementName;
     this.measurement = measurement;
+    this.logger = logger.child({ datasetName, measurementName });
 
     this.run();
   }
@@ -40,7 +44,10 @@ export class HeadMonitor {
     }
     this.measuring = true;
     this.doMeasureDelay(blockNumber, timestamp)
-      .catch((error) => this.log(`delay measurement failed:`, error))
+      .catch((error) => this.logger.error({
+        message: 'Delay measurement failed',
+        error: ensureError(error),
+      }))
       .finally(() => { this.measuring = false; });
   }
 
@@ -54,12 +61,19 @@ export class HeadMonitor {
     const delay = timestamp - reference;
 
     recordDelay(this.datasetName, this.measurementName, delay);
-    this.log(`block ${blockNumber} delay: ${delay}ms`);
+    this.logger.debug({
+      message: `Block ${blockNumber} delay: ${delay}ms`,
+      blockNumber,
+      delayMs: delay,
+    });
   }
 
   private async* streamBlocks(): AsyncGenerator<{ blockNumber: number; timestamp: number }> {
     let lastBlock = await this.getLastBlock();
-    this.log("Starting streaming from block", lastBlock + 1);
+    this.logger.info({
+      message: `Starting stream from block ${lastBlock + 1}`,
+      fromBlock: lastBlock + 1,
+    });
 
     while (true) {
       try {
@@ -80,7 +94,11 @@ export class HeadMonitor {
 
         if (response.status === 503) {
           const delayMs = getRetryAfterMs(response, 1000);
-          this.log(`got 503, retrying in ${delayMs}ms`);
+          this.logger.warn({
+            message: `Stream request returned 503, retrying in ${delayMs}ms`,
+            statusCode: response.status,
+            retryDelayMs: delayMs,
+          });
           await sleep(delayMs);
           continue;
         }
@@ -108,7 +126,12 @@ export class HeadMonitor {
         lastBlock = newBlock;
         this.lastBlockTimestamp = toMilliseconds(blockData.header.timestamp);
       } catch (error) {
-        this.log(`error during stream request to ${this.measurement.target.url}, retrying in 1000ms:`, error);
+        this.logger.error({
+          message: `Stream request to ${this.measurement.target.url} failed, retrying in 1000ms`,
+          error: ensureError(error),
+          url: this.measurement.target.url,
+          retryDelayMs: 1000,
+        });
         await sleep(1000);
       }
     }
@@ -131,14 +154,24 @@ export class HeadMonitor {
           return head["number"];
         } else if (response.status === 503) {
           const delayMs = getRetryAfterMs(response, 1000);
-          console.log(`Couldn't fetch head from ${head_url}, got 503, retrying in ${delayMs}ms`);
+          this.logger.warn({
+            message: `Head request to ${head_url} returned 503, retrying in ${delayMs}ms`,
+            statusCode: response.status,
+            url: head_url,
+            retryDelayMs: delayMs,
+          });
           await sleep(delayMs);
         } else {
           const body = await response.text();
           throw new Error(`HTTP ${response.status} ${body}`);
         }
       } catch (error) {
-        console.log(`Couldn't fetch head from ${head_url}, retrying in 1000ms:`, error);
+        this.logger.error({
+          message: `Head request to ${head_url} failed, retrying in 1000ms`,
+          error: ensureError(error),
+          url: head_url,
+          retryDelayMs: 1000,
+        });
         await sleep(1000);
       }
     }
@@ -162,7 +195,11 @@ export class HeadMonitor {
 
         return Number.parseInt(await response.text());
       } catch (error) {
-        this.log(`request to ${url} failed:`, error);
+        this.logger.error({
+          message: `Reference timestamp request to ${url} failed`,
+          error: ensureError(error),
+          url,
+        });
       }
     });
     const results = (await Promise.all(futures)).filter((x) => x !== undefined) as number[];
@@ -189,7 +226,4 @@ export class HeadMonitor {
     }
   }
 
-  private log(msg: string, ...args: any[]) {
-    console.log(`[${this.datasetName}.${this.measurementName}] ${msg}`, ...args);
-  }
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,4 +1,5 @@
 import { Config, loadConfig } from './config';
+import { logger } from './logger';
 import { HeadMonitor } from './measurement';
 import { MetricsServer } from './metrics_server';
 
@@ -17,12 +18,19 @@ export class Service {
 
   async start(): Promise<void> {
     await this.metricsServer.start();
-    console.log(`Metrics server listening on port ${this.port}`);
+    logger.info({
+      message: `Metrics server listening on port ${this.port}`,
+      port: this.port,
+    });
 
     for (const [datasetName, dataset] of Object.entries(this.config.datasets ?? {})) {
       let monitors = [];
       for (const [measurementName, measurement] of Object.entries(dataset.measurements)) {
-        console.log(`Monitoring ${datasetName}.${measurementName}`);
+        logger.info({
+          message: `Monitoring ${datasetName}.${measurementName}`,
+          datasetName,
+          measurementName,
+        });
 
         monitors.push(new HeadMonitor(
           datasetName,


### PR DESCRIPTION
## Summary

- Replace console logging with structured Pino logging.
- Move successful per-block delay measurements to the `debug` level.
- Keep startup messages at `info`, retries at `warn`, and failures at `error`.
- Bump the release version to `0.2.7`.
- Update `yaml` to a patched version.

Set `LOG_LEVEL=debug` to include successful per-block measurements. The default `LOG_LEVEL=info` suppresses them.

## Validation

- `npm ci`
- `npm run build`
- `npm test` — 14 passing
- `npm audit` — 0 vulnerabilities
- Smoke-tested default `info` and opt-in `debug` output
