### PR TITLE
fix: back off per reference endpoint instead of probing every block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "head-monitor",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "head-monitor",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "ISC",
       "dependencies": {
         "commander": "^14.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "head-monitor",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/measurement.test.ts
+++ b/src/measurement.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { getRetryAfterMs } from './utils';
+import { getRetryAfterMs, EndpointBackoff } from './utils';
 
 // Test the retry logic extracted into getRetryAfterMs.
 // HeadMonitor itself starts an infinite loop in its constructor,
@@ -48,5 +48,69 @@ describe('503 retry delay calculation', () => {
     const resp = mockResponse(503, { 'Retry-After': 'not-a-number' });
     const delay = getRetryAfterMs(resp, 1000);
     assert.strictEqual(delay, 1000);
+  });
+});
+
+describe('reference endpoint backoff', () => {
+  const URL_A = 'http://a.evm-hotblocks';
+  const URL_B = 'http://b.evm-hotblocks';
+
+  it('does not skip an endpoint that has never failed', () => {
+    const backoff = new EndpointBackoff();
+    assert.strictEqual(backoff.shouldSkip(URL_A, 0), false);
+  });
+
+  it('skips for the backoff window after a failure, then retries', () => {
+    const backoff = new EndpointBackoff(1000, 60000);
+    assert.strictEqual(backoff.recordFailure(URL_A, 0), 1000);
+    assert.strictEqual(backoff.shouldSkip(URL_A, 999), true);
+    assert.strictEqual(backoff.shouldSkip(URL_A, 1000), false);
+  });
+
+  it('doubles the delay on consecutive failures', () => {
+    const backoff = new EndpointBackoff(1000, 60000);
+    assert.strictEqual(backoff.recordFailure(URL_A, 0), 1000);
+    assert.strictEqual(backoff.recordFailure(URL_A, 1000), 2000);
+    assert.strictEqual(backoff.recordFailure(URL_A, 3000), 4000);
+    assert.strictEqual(backoff.recordFailure(URL_A, 7000), 8000);
+  });
+
+  it('caps the delay at maxMs', () => {
+    const backoff = new EndpointBackoff(1000, 5000);
+    let delay = 0;
+    for (let i = 0; i < 20; i++) delay = backoff.recordFailure(URL_A, 0);
+    assert.strictEqual(delay, 5000);
+  });
+
+  it('resets to no backoff after a success', () => {
+    const backoff = new EndpointBackoff(1000, 60000);
+    backoff.recordFailure(URL_A, 0);
+    backoff.recordFailure(URL_A, 0);
+    backoff.recordSuccess(URL_A);
+    assert.strictEqual(backoff.shouldSkip(URL_A, 0), false);
+    assert.strictEqual(backoff.failureCount(URL_A), 0);
+    // and the next failure starts from the base delay again
+    assert.strictEqual(backoff.recordFailure(URL_A, 0), 1000);
+  });
+
+  it('tracks endpoints independently', () => {
+    const backoff = new EndpointBackoff(1000, 60000);
+    backoff.recordFailure(URL_A, 0);
+    assert.strictEqual(backoff.shouldSkip(URL_A, 0), true);
+    assert.strictEqual(backoff.shouldSkip(URL_B, 0), false);
+  });
+
+  it('bounds a permanently dead endpoint to maxMs, not chain-head rate', () => {
+    // The regression this guards: a dead reference used to be re-probed once per
+    // block. Over 10 minutes at 20 blocks/s that is 12000 attempts.
+    const backoff = new EndpointBackoff(1000, 60000);
+    const windowMs = 10 * 60 * 1000;
+    let attempts = 0;
+    for (let now = 0; now < windowMs; now += 50) {
+      if (backoff.shouldSkip(URL_A, now)) continue;
+      attempts++;
+      backoff.recordFailure(URL_A, now);
+    }
+    assert.ok(attempts <= 15, `expected <=15 attempts in 10min, got ${attempts}`);
   });
 });

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -1,6 +1,6 @@
 import { Measurement, PortalApi } from './config';
 import { ensureError, logger } from './logger';
-import { sleep, getRetryAfterMs, toMilliseconds } from './utils';
+import { sleep, getRetryAfterMs, toMilliseconds, EndpointBackoff } from './utils';
 import { recordDelay } from './metrics';
 import type { Logger } from 'pino';
 
@@ -11,6 +11,7 @@ export class HeadMonitor {
   public lastBlockTimestamp?: number;
   private measuring = false;
   private readonly logger: Logger;
+  private readonly referenceBackoff = new EndpointBackoff();
 
   constructor(
     datasetName: string,
@@ -179,13 +180,20 @@ export class HeadMonitor {
 
   private async fetchReferenceTimestamp(block: number): Promise<number | undefined> {
     const futures = this.measurement.reference.urls.map(async (base) => {
+      if (this.referenceBackoff.shouldSkip(base)) {
+        return undefined;
+      }
+
       const url = `${base}/block-time/${block}`;
       try {
         const response = await fetch(url.toString(), {
           method: 'GET',
           signal: AbortSignal.timeout(5000)
         });
+        // 404 just means the reference has not reached this block yet -- the
+        // endpoint answered, so it is healthy.
         if (response.status === 404) {
+          this.referenceBackoff.recordSuccess(base);
           return undefined;
         }
         if (!response.ok) {
@@ -193,12 +201,16 @@ export class HeadMonitor {
           throw new Error(`HTTP ${response.status} ${body}`);
         }
 
+        this.referenceBackoff.recordSuccess(base);
         return Number.parseInt(await response.text());
       } catch (error) {
+        const retryDelayMs = this.referenceBackoff.recordFailure(base);
         this.logger.error({
-          message: `Reference timestamp request to ${url} failed`,
+          message: `Reference timestamp request to ${url} failed, skipping this reference for ${retryDelayMs}ms`,
           error: ensureError(error),
           url,
+          retryDelayMs,
+          consecutiveFailures: this.referenceBackoff.failureCount(base),
         });
       }
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,46 @@ export function toMilliseconds(timestamp: number): number {
   return timestamp;
 }
 
+/**
+ * Per-endpoint exponential backoff.
+ *
+ * Reference endpoints are probed once per block, so a fast failure (an unresolvable
+ * name NXDOMAINs in ~1ms) turns into a retry loop that runs at chain head rate. Skipping
+ * the request entirely while an endpoint is in backoff is what keeps that off the wire —
+ * a request that is never issued costs no DNS lookup and logs nothing.
+ */
+export class EndpointBackoff {
+  private readonly baseMs: number;
+  private readonly maxMs: number;
+  private readonly state = new Map<string, { failures: number; nextAttemptMs: number }>();
+
+  constructor(baseMs = 1000, maxMs = 60000) {
+    this.baseMs = baseMs;
+    this.maxMs = maxMs;
+  }
+
+  shouldSkip(url: string, now: number = Date.now()): boolean {
+    const entry = this.state.get(url);
+    return entry !== undefined && now < entry.nextAttemptMs;
+  }
+
+  /** Returns the delay applied, so the caller can log the transition once per window. */
+  recordFailure(url: string, now: number = Date.now()): number {
+    const failures = (this.state.get(url)?.failures ?? 0) + 1;
+    const delayMs = Math.min(this.baseMs * 2 ** (failures - 1), this.maxMs);
+    this.state.set(url, { failures, nextAttemptMs: now + delayMs });
+    return delayMs;
+  }
+
+  recordSuccess(url: string): void {
+    this.state.delete(url);
+  }
+
+  failureCount(url: string): number {
+    return this.state.get(url)?.failures ?? 0;
+  }
+}
+
 export function getRetryAfterMs(response: Response, defaultMs: number): number {
   const header = response.headers.get('Retry-After');
   if (header == null) return defaultMs;


### PR DESCRIPTION
## Problem

`fetchReferenceTimestamp` probes every reference URL once per block and, on failure, logs and forgets. There is no backoff and no memory of the failure, so a permanently broken endpoint is retried at chain-head rate.

An unresolvable name NXDOMAINs in ~1 ms, so the failure path is *faster* than the success path — the loop spins as fast as blocks arrive.

Measured on `sqd-compute-cluster` (2026-07-29):

| | |
|---|---|
| Cluster DNS | 833 q/s, **94% NXDOMAIN** |
| From the 2 `hotblocks-db` nodes | 750 q/s (**90%**) |
| Per sidecar | ~20 `getaddrinfo ENOTFOUND`/s |

15 stale service names across the hotblocks configs were driving essentially all of it. `ndots:5` plus 4 search domains turns one dead lookup into 10 queries (5 names × A/AAAA), and nodelocaldns caches denials for only 5 s vs 30 s for successes — so dead names are re-queried 6× more often than live ones.

## Fix

A per-endpoint `EndpointBackoff`. The load-bearing part is that a backed-off endpoint is **skipped before the request is issued** — a request that is never made costs no DNS lookup and logs nothing.

- delay doubles 1s → 60s cap, resets on any answer
- **404 counts as success** — the reference answered, it just hasn't reached that block yet
- endpoints tracked independently, so one dead reference doesn't mute a healthy one
- error logging drops from once per block to once per backoff window

Worst case for a permanently dead endpoint goes from ~12,000 attempts per 10 min (at 20 blocks/s) to ~14.

## Notes

- No behaviour change when references are healthy: success resets state, so a steady endpoint is never skipped.
- `fetchReferenceTimestamp` already tolerated a reference returning nothing (`results.length === 0` → skip the measurement), so skipping is on an existing path.
- Backoff is per `HeadMonitor` instance, i.e. per dataset+measurement. Two datasets sharing a URL back off independently — deliberate, since it keeps the state simple and the ceiling is still 1 attempt/60s each.

## Test

21/21 pass (`npm test`), including a regression test bounding a permanently dead endpoint to ≤15 attempts per 10 minutes.

Companion infra PR retires the 15 stale service names; this change is what stops the next rename from recreating the storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)